### PR TITLE
Ensures this addon calls `_super` in `included`

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@
 module.exports = {
   name: 'ember-truncate',
   included: function(app) {
+    this._super.included.apply(this, arguments);
+    
     app.import('vendor/styles/truncate-multiline.css');
   }
 };


### PR DESCRIPTION
Ember. 3.0.0 [removed the use of `Ember.WeakMap`](https://github.com/emberjs/ember.js/pull/15878) in favor of native `WeakMap`. As part of our application's migration to 3.0.0, we found an issue when using that version in conjunction with this addon's use of `ember-weakmap`. 

Specifically, because this addon implements [an `included` hook](https://github.com/nickiaconis/ember-truncate/blob/master/index.js#L6) but does not call `_super` in that hook, child addons that also implement an `included` hook don't have their hook invoked. 

This is reproducible using the following steps:

1. create a new ember app with the latest version of ember cli - `ember new foo --yarn`
1. add ember-truncate - `yarn add ember-truncate@0.3.4`
1. run tests - `ember t`